### PR TITLE
Solution

### DIFF
--- a/.infrastructure/clusterIp.yml
+++ b/.infrastructure/clusterIp.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: todoapp-service
-  namespace: todoapp
+  namespace: mateapp
 spec:
   type: ClusterIP
   selector:

--- a/.infrastructure/cronjob.yml
+++ b/.infrastructure/cronjob.yml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: todoapp-health-check
+spec:
+  schedule: "*/4 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: health-check
+            image: radial/busyboxplus:curl
+            args:
+            - /bin/sh
+            - -c
+            - curl http://todoapp.cluster.local/api/health
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "400m"
+              limits:
+                memory: "128Mi"
+                cpu: "800m"
+          restartPolicy: OnFailure
+      backoffLimit: 6
+  successfulJobsHistoryLimit: 10
+  failedJobsHistoryLimit: 5
+  concurrencyPolicy: Allow

--- a/.infrastructure/daemonset.yml
+++ b/.infrastructure/daemonset.yml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: busybox-curler
+  namespace: mateapp
+  labels:
+    app: busybox-curler
+spec:
+  selector:
+    matchLabels:
+      app: busybox-curler
+  template:
+    metadata:
+      labels:
+        app: busybox-curler
+    spec:
+      containers:
+      - name: busybox-curler
+        image: radial/busyboxplus:curl
+        args:
+        - /bin/sh
+        - -c
+        - >
+          while true; do
+            curl http://todoapp-service.mateapp.svc.cluster.local/api/health;
+            sleep 5;
+          done
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "100Mi"
+          limits:
+            cpu: "400m"
+            memory: "200Mi"

--- a/.infrastructure/deployment.yml
+++ b/.infrastructure/deployment.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: todoapp
-  namespace: todoapp
+  namespace: mateapp
 spec:
   strategy:
     type: RollingUpdate
@@ -22,14 +22,19 @@ spec:
         image: ikulyk404/todoapp:3.0.0
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "150m"
+            memory: "400Mi"
+            cpu: "200m"
           limits:
-            memory: "256Mi"
-            cpu: "150m"
+            memory: "800Mi"
+            cpu: "400m"
         env:
         - name: PYTHONUNBUFFERED
           value: "1"
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mysecret
+              key: SECRET_KEY  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/.infrastructure/mysecret.yml
+++ b/.infrastructure/mysecret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+  namespace: mateapp
+type: Opaque
+data:
+  SECRET_KEY: MTIzNA==

--- a/.infrastructure/nodeport.yml
+++ b/.infrastructure/nodeport.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: todoapp-nodeport
-  namespace: todoapp
+  namespace: mateapp
 spec:
   type: NodePort
   selector:

--- a/README.md
+++ b/README.md
@@ -49,3 +49,20 @@ Create a kubernetes manifest for a pod which will containa ToDo app container:
 1. `README.md` should be updated with the instructions on how to deploy `daemonset.yml` and `cronjob.yml` to the cluster.
 1. `README.md` should be updated with the instructions on how to validate the solution. (Logs for the `daemonset` and `cronjob` should be present)
 1. Create PR with your changes and attach it for validation on a platform.
+
+
+# Deploy the DaemonSet:
+
+To deploy the daemonset.yml  execute the following command:
+`kubectl apply -f .infrastructure/daemonset.yml -n mateapp`
+
+# Deploy the CronJob:
+
+To deploy the cronjob.yml  execute the following command:
+`kubectl apply -f cronjob.yml -n mateapp`
+
+# Validating the Solution
+DaemonSet and CronJob Logs Logs:
+
+`kubectl logs <name_of_pod>  -n mateapp`
+


### PR DESCRIPTION
In this specific DaemonSet, I think there's no need to specify ports because it's used exclusively for making curl requests to an internal Kubernetes service and isn't listening on any port. Also, there's no need to associate this DaemonSet with the todoapp application through labels. That's because, in this case, the DaemonSet is not a direct component of the application and only serves auxiliary or monitoring functions.